### PR TITLE
initial start to pushing phergie away from php 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "source": "https://github.com/phergie/phergie-irc-bot-react-development"
     },
     "require": {
-        "php": ">=5.6.0",
-        "phpunit/phpunit": "~4.6",
+        "php": ">=5.6.0 || 7.0",
+        "phpunit/phpunit": "~5.0",
         "phake/phake": "~2.0",
         "codeclimate/php-test-reporter": "~0.3",
         "symfony/config": "~2.0",


### PR DESCRIPTION
http://php.net/supported-versions.php

PHP 5.6 is now only in security updates, and we want to start pushing developers into PHP 7.x. This PR starts that effort. We dont remove 5.6 yet, but Ive updated Composer to look for 5.6 or 7.0. I think that we should keep it like this for about two months, make an announcement about our efforts forward and go forward. Ive also updated PHPUnit to 5.x since the 4.x series is officially out of support. 